### PR TITLE
feat(admin): add delete, activate/deactivate and filter translations

### DIFF
--- a/frontend/src/translations/en.ts
+++ b/frontend/src/translations/en.ts
@@ -194,6 +194,12 @@ export const en = {
     showing: 'Showing',
     of: 'of',
     viewAll: 'View all',
+    deleteRecord: 'Delete Record',
+    confirmDelete: 'Are you sure you want to delete this record? This action cannot be undone.',
+    deactivate: 'Deactivate',
+    activate: 'Activate',
+    filterByStatus: 'Filter by Status',
+    allStatuses: 'All Statuses',
   },
   footer: {
     tagline: 'Secure, centralized land verification platform for Cameroon. Eliminating fraud, one title at a time.',

--- a/frontend/src/translations/fr.ts
+++ b/frontend/src/translations/fr.ts
@@ -196,6 +196,12 @@ export const fr: Translations = {
     showing: 'Affichage',
     of: 'sur',
     viewAll: 'Voir tout',
+    deleteRecord: "Supprimer l'enregistrement",
+    confirmDelete: "Êtes-vous sûr de vouloir supprimer cet enregistrement ? Cette action est irréversible.",
+    deactivate: 'Désactiver',
+    activate: 'Activer',
+    filterByStatus: 'Filtrer par Statut',
+    allStatuses: 'Tous les Statuts',
   },
   footer: {
     tagline: 'Plateforme sécurisée et centralisée de vérification foncière pour le Cameroun. Éliminons la fraude, un titre à la fois.',


### PR DESCRIPTION
Adds missing admin panel UI translations for delete confirmation, activate/deactivate actions, and status filter in both English and French.

**Changes:**
- Added `deleteRecord`, `confirmDelete`, `deactivate`, `activate`, `filterByStatus`, `allStatuses` to EN and FR translation files.