### PR TITLE
feat(browse-ui): add sort and load-more translations for browse page

### DIFF
--- a/frontend/src/translations/en.ts
+++ b/frontend/src/translations/en.ts
@@ -149,6 +149,11 @@ export const en = {
     reset: 'Reset',
     parcelsFound: 'parcel(s) found',
     noResults: 'No land parcels found for the selected filters.',
+    loadMore: 'Load More',
+    noMore: 'No more parcels to load.',
+    sortBy: 'Sort by',
+    sortNewest: 'Newest First',
+    sortOldest: 'Oldest First',
   },
   landDetail: {
     back: '← Back to Search',

--- a/frontend/src/translations/fr.ts
+++ b/frontend/src/translations/fr.ts
@@ -151,6 +151,11 @@ export const fr: Translations = {
     reset: 'Réinitialiser',
     parcelsFound: 'parcelle(s) trouvée(s)',
     noResults: 'Aucune parcelle trouvée pour les filtres sélectionnés.',
+    loadMore: 'Charger Plus',
+    noMore: 'Plus de parcelles à charger.',
+    sortBy: 'Trier par',
+    sortNewest: 'Plus Récent',
+    sortOldest: 'Plus Ancien',
   },
   landDetail: {
     back: '← Retour à la Recherche',


### PR DESCRIPTION
Adds sorting and pagination UI strings to the browse section in both EN and FR translations.

**Changes:**
- Added `loadMore`, `noMore`, `sortBy`, `sortNewest`, `sortOldest` to EN and FR.