### PR TITLE
feat(map): add map tooltip and location translations

### DIFF
--- a/frontend/src/translations/en.ts
+++ b/frontend/src/translations/en.ts
@@ -209,6 +209,13 @@ export const en = {
     privacyPolicy: 'Privacy Policy',
     terms: 'Terms of Use',
   },
+  map: {
+    tooltip: 'Click to view parcel details',
+    loading: 'Loading map…',
+    noLocation: 'Location not available for this parcel.',
+    zoomHint: 'Use scroll wheel to zoom in/out',
+    markerLabel: 'Land parcel location',
+  },
   notFound: {
     title: 'Page Not Found',
     subtitle: "The page you're looking for doesn't exist or has been moved.",

--- a/frontend/src/translations/fr.ts
+++ b/frontend/src/translations/fr.ts
@@ -211,6 +211,13 @@ export const fr: Translations = {
     privacyPolicy: 'Politique de Confidentialité',
     terms: "Conditions d'Utilisation",
   },
+  map: {
+    tooltip: 'Cliquez pour voir les détails de la parcelle',
+    loading: 'Chargement de la carte…',
+    noLocation: "Emplacement non disponible pour cette parcelle.",
+    zoomHint: 'Utilisez la molette pour zoomer',
+    markerLabel: 'Emplacement de la parcelle',
+  },
   notFound: {
     title: 'Page Introuvable',
     subtitle: "La page que vous recherchez n'existe pas ou a été déplacée.",


### PR DESCRIPTION
Adds a new `map` translation section for the interactive Leaflet map component in both EN and FR.

**Changes:**
- Added `map` section with `tooltip`, `loading`, `noLocation`, `zoomHint`, `markerLabel` keys