### PR TITLE
feat(ci): add GitHub Actions CI pipeline for TypeScript checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI — TypeScript Check
+
+on:
+  push:
+    branches:
+      - develop
+      - 'feature/**'
+      - 'hotfix/**'
+  pull_request:
+    branches:
+      - develop
+      - master
+      - 'release/**'
+
+jobs:
+  backend:
+    name: Backend — TypeScript Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm install
+
+      - name: Generate Prisma client
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/land_verification
+        run: npx prisma generate
+
+      - name: TypeScript check
+        working-directory: backend
+        run: npx tsc --noEmit
+
+  frontend:
+    name: Frontend — TypeScript Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: TypeScript check
+        working-directory: frontend
+        run: npx tsc --noEmit


### PR DESCRIPTION
Closes #25

Implements the GitHub Actions CI/CD pipeline that automatically runs on every push and pull request.

**What it does:**
- Triggers on every push to `develop`, `feature/**`, and `hotfix/**` branches
- Triggers on every PR targeting `develop`, `master`, and `release/**`
- Runs two parallel jobs:
  1. **Backend** — installs dependencies, generates Prisma client, runs TypeScript check
  2. **Frontend** — installs dependencies, runs TypeScript check

**Result:** Every PR will show a green checkmark if the code is clean, or a red cross if there are TypeScript errors — before any merge happens.