### PR TITLE
fix(backend): resolve CI TypeScript error in AuditLog Prisma Json field

### DIFF
--- a/backend/src/controllers/admin.controller.ts
+++ b/backend/src/controllers/admin.controller.ts
@@ -131,7 +131,7 @@ export async function deactivateLand(req: AuthRequest, res: Response): Promise<v
   await prisma.landParcel.update({ where: { id }, data: { isActive: false } });
 
   await prisma.auditLog.create({
-    data: { landId: id, userId: adminId, action: 'DEACTIVATE', changes: null },
+    data: { landId: id, userId: adminId, action: 'DEACTIVATE' },
   });
 
   res.json({ message: 'Land record deactivated successfully.' });


### PR DESCRIPTION
Fixes the red cross on CI introduced when the pipeline ran for the first time.

**Root cause:** `changes: null` was passed to a Prisma `Json?` field. Prisma's strict TypeScript types do not accept plain `null` for optional JSON fields — the field should simply be omitted.

**Fix:** Removed `changes: null` from the DEACTIVATE audit log entry. Since the field is optional in the schema, omitting it is correct and clean.