### PR TITLE
fix(ci): enforce TypeScript check only on integration branches, not feature/**

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - develop
-      - 'feature/**'
+      - master
+      - 'release/**'
       - 'hotfix/**'
   pull_request:
     branches:


### PR DESCRIPTION
Remove feature/** from push triggers. Feature branches are intentionally partial — CI should gate on develop/master/release, not on in-progress work.