### PR TITLE
fix(ci): propagate CI workflow fix to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - develop
-      - 'feature/**'
+      - master
+      - 'release/**'
       - 'hotfix/**'
   pull_request:
     branches:


### PR DESCRIPTION
Bring the CI fix from develop into master: stops feature/** push triggers that caused false red crosses on partial feature branches.