### PR TITLE
fix: auto-seed admin + fix missing https:// in Vercel build

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,8 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import path from 'path';
 import fs from 'fs';
+import { PrismaClient, Role } from '@prisma/client';
+import bcrypt from 'bcryptjs';
 import authRoutes from './routes/auth.routes';
 import landRoutes from './routes/land.routes';
 import adminRoutes from './routes/admin.routes';
@@ -82,6 +84,27 @@ process.on('unhandledRejection', (reason) => {
 app.listen(Number(PORT), '0.0.0.0', () => {
   console.log(`Server running on port ${PORT}`);
   console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
+  seedAdminIfNeeded();
 });
+
+async function seedAdminIfNeeded() {
+  const prisma = new PrismaClient();
+  try {
+    const adminEmail = process.env.ADMIN_EMAIL || 'admin@landverify.cm';
+    const existing = await prisma.user.findUnique({ where: { email: adminEmail } });
+    if (!existing) {
+      const adminPassword = process.env.ADMIN_PASSWORD || 'Admin@1234';
+      const passwordHash = await bcrypt.hash(adminPassword, 12);
+      await prisma.user.create({
+        data: { name: 'System Administrator', email: adminEmail, passwordHash, role: Role.ADMIN },
+      });
+      console.log(`[SEED] Admin user created: ${adminEmail}`);
+    }
+  } catch (e) {
+    console.error('[SEED] Failed to seed admin:', e);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
 
 export default app;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,9 +1,15 @@
 import axios from 'axios';
 
-const backendUrl = (
+let backendUrl = (
   import.meta.env.VITE_BACKEND_URL ||
   'https://land-verification-website-production.up.railway.app'
 ).replace(/\/$/, '');
+
+// Guard: ensure protocol is always present (env var may be set without https://)
+if (backendUrl && !backendUrl.startsWith('http')) {
+  backendUrl = `https://${backendUrl}`;
+}
+
 const baseURL = `${backendUrl}/api`;
 
 const api = axios.create({ baseURL });


### PR DESCRIPTION
## What this fixes

### 1. Admin login was impossible
The seed script was never run on Railway, so `admin@landverify.cm` didn't exist. Added auto-seeding on server startup — the admin is created automatically when the server boots if it doesn't exist yet.

**Credentials after this deploy:**
- Email: `admin@landverify.cm`
- Password: `Admin@1234`

### 2. Register/login broken from Vercel frontend
Vercel had `VITE_BACKEND_URL` set without the `https://` protocol (`land-verification-website-production.up.railway.app` instead of `https://...`). Axios was constructing invalid non-absolute URLs so every API call failed silently. Added a protocol guard that prepends `https://` if missing.

## Test plan
- [ ] Merge → Railway redeploys → logs show `[SEED] Admin user created`
- [ ] Login at https://land-verification-website.vercel.app/login with `admin@landverify.cm` / `Admin@1234`
- [ ] Register a new account from the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)