### PR TITLE
feat(seed): seed 5 demo land parcels on startup

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import path from 'path';
 import fs from 'fs';
-import { PrismaClient, Role } from '@prisma/client';
+import { PrismaClient, Role, LandStatus } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 import authRoutes from './routes/auth.routes';
 import landRoutes from './routes/land.routes';
@@ -91,17 +91,79 @@ async function seedAdminIfNeeded() {
   const prisma = new PrismaClient();
   try {
     const adminEmail = process.env.ADMIN_EMAIL || 'admin@landverify.cm';
-    const existing = await prisma.user.findUnique({ where: { email: adminEmail } });
-    if (!existing) {
+    let admin = await prisma.user.findUnique({ where: { email: adminEmail } });
+    if (!admin) {
       const adminPassword = process.env.ADMIN_PASSWORD || 'Admin@1234';
       const passwordHash = await bcrypt.hash(adminPassword, 12);
-      await prisma.user.create({
+      admin = await prisma.user.create({
         data: { name: 'System Administrator', email: adminEmail, passwordHash, role: Role.ADMIN },
       });
       console.log(`[SEED] Admin user created: ${adminEmail}`);
     }
+
+    const landCount = await prisma.landParcel.count();
+    if (landCount === 0) {
+      const demoLands = [
+        {
+          titleNumber: 'TF-001-YAOUNDE', ownerName: 'Jean-Pierre Mbarga', quarter: 'Bastos',
+          areaSqm: 500, gpsLat: 3.8697, gpsLng: 11.5212, status: LandStatus.VALID,
+          titleApprovedYear: 2018, landUseType: 'RESIDENTIAL', uploadedById: admin.id,
+          ownership: [
+            { ownerName: 'Famille Mbarga', ownershipType: 'ORIGINAL', fromYear: 1995, toYear: 2010 },
+            { ownerName: 'Mbarga Pierre', ownershipType: 'INHERITANCE', fromYear: 2010, toYear: 2018 },
+            { ownerName: 'Jean-Pierre Mbarga', ownershipType: 'PURCHASE', fromYear: 2018, toYear: null },
+          ],
+        },
+        {
+          titleNumber: 'TF-002-YAOUNDE', ownerName: 'Marie-Claire Ngo Biyik', quarter: 'Nlongkak',
+          areaSqm: 300, gpsLat: 3.8741, gpsLng: 11.5176, status: LandStatus.VALID,
+          titleApprovedYear: 2021, landUseType: 'COMMERCIAL', uploadedById: admin.id,
+          ownership: [
+            { ownerName: 'État du Cameroun', ownershipType: 'ORIGINAL', fromYear: 1980, toYear: 2015 },
+            { ownerName: 'Ngo Biyik Emile', ownershipType: 'PURCHASE', fromYear: 2015, toYear: 2021 },
+            { ownerName: 'Marie-Claire Ngo Biyik', ownershipType: 'INHERITANCE', fromYear: 2021, toYear: null },
+          ],
+        },
+        {
+          titleNumber: 'TF-003-YAOUNDE', ownerName: 'Emmanuel Tchio', quarter: 'Melen',
+          areaSqm: 750, gpsLat: 3.8612, gpsLng: 11.5098, status: LandStatus.SUSPICIOUS,
+          notes: 'Proximity overlap detected with parcel TF-004.',
+          titleApprovedYear: 2019, landUseType: 'AGRICULTURAL', uploadedById: admin.id,
+          ownership: [
+            { ownerName: 'Tchio Mathieu', ownershipType: 'ORIGINAL', fromYear: 2000, toYear: 2019 },
+            { ownerName: 'Emmanuel Tchio', ownershipType: 'INHERITANCE', fromYear: 2019, toYear: null },
+          ],
+        },
+        {
+          titleNumber: 'TF-004-YAOUNDE', ownerName: 'Paul Ekotto', quarter: 'Melen',
+          areaSqm: 400, gpsLat: 3.8618, gpsLng: 11.5102, status: LandStatus.DUPLICATE,
+          notes: 'GPS coordinates overlap with TF-003-YAOUNDE.',
+          titleApprovedYear: 2020, landUseType: 'RESIDENTIAL', uploadedById: admin.id,
+          ownership: [
+            { ownerName: 'Paul Ekotto', ownershipType: 'PURCHASE', fromYear: 2020, toYear: null },
+          ],
+        },
+        {
+          titleNumber: 'TF-005-DOUALA', ownerName: 'Christelle Fosso', quarter: 'Bonanjo',
+          areaSqm: 620, gpsLat: 4.0465, gpsLng: 9.7016, status: LandStatus.VALID,
+          titleApprovedYear: 2016, landUseType: 'COMMERCIAL', uploadedById: admin.id,
+          ownership: [
+            { ownerName: 'Fosso Enterprises SARL', ownershipType: 'ORIGINAL', fromYear: 2005, toYear: 2016 },
+            { ownerName: 'Christelle Fosso', ownershipType: 'PURCHASE', fromYear: 2016, toYear: null },
+          ],
+        },
+      ];
+
+      for (const { ownership, ...land } of demoLands) {
+        const created = await prisma.landParcel.create({ data: land });
+        await prisma.ownershipRecord.createMany({
+          data: ownership.map((o) => ({ ...o, landId: created.id })),
+        });
+      }
+      console.log(`[SEED] ${demoLands.length} demo land parcels created`);
+    }
   } catch (e) {
-    console.error('[SEED] Failed to seed admin:', e);
+    console.error('[SEED] Failed:', e);
   } finally {
     await prisma.$disconnect();
   }


### PR DESCRIPTION
Seeds 5 demo land parcels (Yaoundé + Douala) automatically on startup when the database is empty. Also fixes the `LandStatus` import that was flagged as unused in the previous commit.

**After merging:** browse page and search will show real data immediately after Railway redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)