### PR TITLE
fix(deploy): move @types/compression to dependencies for Railway build

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.14.0",
         "@types/bcryptjs": "^2.4.6",
+        "@types/compression": "^1.8.1",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.6",
@@ -30,7 +31,6 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@types/compression": "^1.8.1",
         "ts-node-dev": "^2.0.0"
       }
     },
@@ -186,7 +186,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
       "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/express": "*",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/multer": "^1.4.11",
+    "@types/compression": "^1.8.1",
     "@types/node": "^20.14.2",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
@@ -35,7 +36,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/compression": "^1.8.1",
     "ts-node-dev": "^2.0.0"
   }
 }


### PR DESCRIPTION
Railway skips devDependencies in production builds. @types/compression was in devDependencies causing TS7016 error. Moved to dependencies like all other @types/* packages.